### PR TITLE
Set the copyright in main and models to 2019

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Randy Barlow
+ * Copyright © 2019-2020 Randy Barlow
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, version 3 of the License.

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Randy Barlow
+ * Copyright © 2019-2020 Randy Barlow
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, version 3 of the License.


### PR DESCRIPTION
Some of the code in main and models was written in 2019, but the
copyright headers weren't written until 2020, which is why they
originally showed 2020. This commit fixes that oversight.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>