### PR TITLE
Move the configuration docs to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,66 @@ This will generate a video file on your system called ```simulation.mp4``` that 
 signal propagating in space. Good job!
 
 
+# Simulation parameter configuration
+
+REMS expects you to define a simulation by providing it with a YAML file describing all the
+parameters. Here is an example config showing all available options, with commented default
+options:
+
+```
+---
+## How many dimensions we have in space. Right now, only 1 is supported.
+dimensions: 1
+## Define a list of signals
+signals:
+  ## This signal is at location 600 in space
+  - location: 600
+    ## Read this path to get the signal. See below for a description of this file.
+    path: examples/1d_signal.bson
+## Define how large the universe should be, in cells
+size: 1920
+## Define how many time steps the simulation should run for
+time: 32768
+## This is a list of oscilloscopes, or outputs for your simulation. Right now, only the movie
+## type is supported, but one could imagine other types added in the future.
+oscilloscopes:
+  - type: movie
+    # How large of a magnitude to use for the y-axis on the graphs
+    ## range: 1.0
+    ## The path to write the movie to
+    path: examples/1d_simulation.mp4
+    ## The framerate of the resulting movie, in Hz
+    ## framerate: 60
+    ## How often to generate a graph in simulation time steps
+    ## graph_period: 16
+    ## The resolution you desire for the resulting video, expressed as an array of two integers
+    ## resolution:
+    ##   - 1920
+    ##   - 1080
+    ## How many snapshots to buffer in memory before handing them off to a Python subprocess to
+    ## generate graphs out of them.
+    ## snapshot_buffer_len: 47
+```
+
+# The signal BSON file
+
+The signals should be defined in a BSON file, with three fields: ```ex```, ```_version```, and
+```dimensions```. ```_version``` should be set to 0, ```dimensions``` should be set to 1, and
+```ex``` should be an array of floating point numbers that express which value the signal
+should have for each time step in the simulation. Here is a YAML example that corresponds in
+spirit to that schema:
+
+```
+---
+_version: 0
+dimensions: 1
+ex:
+  - 0.0
+  - 0.1
+  - 0.2
+  - 0.3
+```
+
 # Links
 
 * [Bugs](https://github.com/bowlofeggs/rems/issues)

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,66 +13,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//! # Simulation parameter configuration
-//!
-//! REMS expects you to define a simulation by providing it with a YAML file describing all the
-//! parameters. Here is an example config showing all available options, with commented default
-//! options:
-//!
-//! ```
-//! ---
-//! ## How many dimensions we have in space. Right now, only 1 is supported.
-//! dimensions: 1
-//! ## Define a list of signals
-//! signals:
-//!   ## This signal is at location 600 in space
-//!   - location: 600
-//!     ## Read this path to get the signal. See below for a description of this file.
-//!     path: examples/1d_signal.bson
-//! ## Define how large the universe should be, in cells
-//! size: 1920
-//! ## Define how many time steps the simulation should run for
-//! time: 32768
-//! ## This is a list of oscilloscopes, or outputs for your simulation. Right now, only the movie
-//! ## type is supported, but one could imagine other types added in the future.
-//! oscilloscopes:
-//!   - type: movie
-//!     # How large of a magnitude to use for the y-axis on the graphs
-//!     ## range: 1.0
-//!     ## The path to write the movie to
-//!     path: examples/1d_simulation.mp4
-//!     ## The framerate of the resulting movie, in Hz
-//!     ## framerate: 60
-//!     ## How often to generate a graph in simulation time steps
-//!     ## graph_period: 16
-//!     ## The resolution you desire for the resulting video, expressed as an array of two integers
-//!     ## resolution:
-//!     ##   - 1920
-//!     ##   - 1080
-//!     ## How many snapshots to buffer in memory before handing them off to a Python subprocess to
-//!     ## generate graphs out of them.
-//!     ## snapshot_buffer_len: 47
-//! ```
-//!
-//! # The signal BSON file
-//!
-//! The signals should be defined in a BSON file, with three fields: ```ex```, ```_version```, and
-//! ```dimensions```. ```_version``` should be set to 0, ```dimensions``` should be set to 1, and
-//! ```ex``` should be an array of floating point numbers that express which value the signal
-//! should have for each time step in the simulation. Here is a YAML example that corresponds in
-//! spirit to that schema:
-//!
-//! ```
-//! ---
-//! _version: 0
-//! dimensions: 1
-//! ex:
-//!   - 0.0
-//!   - 0.1
-//!   - 0.2
-//!   - 0.3
-//! ```
-
 use std::error;
 use std::fs::File;
 use std::io::BufReader;


### PR DESCRIPTION
I had previously stashed the configuration docs into config.rs,
believing that docs.rs would render them for me. For some reason
it did not, perhaps because this is a CLI and not a library. In
any case, I know they will be rendered when in the README.

fixes #7

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>