### PR TITLE
Save movie frames to a temporary directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rayon = "1.3"
 serde = {version = "1.0", features = ["derive"]}
 serde_yaml = "0.8"
 structopt = "0.3"
+tempfile = "3"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Allocate a temporary directory per Oscilloscope for movie frames to be
stored in before they're rendered into a movie

Signed-off-by: Jeremy Cline <jeremy@jcline.org>