### PR TITLE
Separate 1D config code into a config::d1 module

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,9 @@ use std::io::BufReader;
 
 use serde::Deserialize;
 
+// This allows us to namespace 1D configuration models.
+pub mod d1;
+
 /// Return the user's config as a Simulation.
 ///
 /// # Arguments
@@ -38,86 +41,6 @@ pub fn read_config(config_file_path: &str) -> Result<Simulation, Box<dyn error::
     Ok(config)
 }
 
-// Serde requires the use of functions to define defaults on struct fields, so these functions
-// define those defaults.
-fn default_framerate() -> u16 {
-    60
-}
-fn default_graph_period() -> u16 {
-    16
-}
-fn default_range() -> f32 {
-    1.0
-}
-fn default_resolution() -> (u16, u16) {
-    (1920, 1080)
-}
-fn default_snapshot_buffer_len() -> u16 {
-    47
-}
-
-/// The Movie allows the user to request that a video be made of the E and H values for the entire
-/// simulation space across all of time.
-#[derive(PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
-pub struct Movie {
-    /// The framerate for the resulting movie, in Hz.
-    #[serde(default = "default_framerate")]
-    pub framerate: u16,
-    /// How often to capture a frame for the video, in simulation time steps.
-    #[serde(default = "default_graph_period")]
-    pub graph_period: u16,
-    /// How large of a magnitude to graph on the y-axis.
-    #[serde(default = "default_range")]
-    pub range: f32,
-    /// Where to store the movie at the end of the simulation.
-    pub path: String,
-    /// What resolution to use for the movie, in pixels.
-    #[serde(default = "default_resolution")]
-    pub resolution: (u16, u16),
-    /// How many snapshots to buffer in memory before starting a child process to render them into
-    /// movie frames.
-    #[serde(default = "default_snapshot_buffer_len")]
-    pub snapshot_buffer_len: u16,
-}
-
-/// An Oscilloscope is a tool for the user to request for simulation data to be captured.
-#[derive(PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
-#[serde(tag = "type")]
-pub enum Oscilloscope {
-    /// Record a movie of the simulation.
-    Movie(Movie),
-}
-
-/// Define a signal to place into the simulation space.
-#[derive(PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
-pub struct Signal {
-    /// Where in the simulation space to place the signal.
-    pub location: usize,
-    /// A path to a BSON file on disk that contains the signal values.
-    pub path: String,
-}
-
-/// Define a configuration for a 1D simulation.
-#[derive(PartialEq, Deserialize)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "snake_case")]
-pub struct OneDSimulation {
-    /// A list of oscilloscopes to measure data in the simulation.
-    pub oscilloscopes: Vec<Oscilloscope>,
-    /// A list of signals to place into the simulation space.
-    pub signals: Vec<Signal>,
-    /// How many units large the universe is.
-    pub size: u64,
-    /// How long the universe will last until it all comes to an end.
-    pub time: u64,
-}
-
 /// Define a configuration for a simulation.
 #[derive(PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -126,5 +49,5 @@ pub struct OneDSimulation {
 pub enum Simulation {
     /// Define a configuration for a 1D simulation.
     #[serde(rename(deserialize = "1"))]
-    OneDimensional(OneDSimulation),
+    OneDimensional(d1::Simulation),
 }

--- a/src/config/d1.rs
+++ b/src/config/d1.rs
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2020 Randy Barlow
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! This module defines the schema and utilities for handling 1-dimensional simulation
+//! configuration files.
+
+use serde::Deserialize;
+
+// Serde requires the use of functions to define defaults on struct fields, so these functions
+// define those defaults.
+fn default_framerate() -> u16 {
+    60
+}
+fn default_graph_period() -> u16 {
+    16
+}
+fn default_range() -> f32 {
+    1.0
+}
+fn default_resolution() -> (u16, u16) {
+    (1920, 1080)
+}
+fn default_snapshot_buffer_len() -> u16 {
+    47
+}
+
+/// The Movie allows the user to request that a video be made of the E and H values for the entire
+/// simulation space across all of time.
+#[derive(PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct Movie {
+    /// The framerate for the resulting movie, in Hz.
+    #[serde(default = "default_framerate")]
+    pub framerate: u16,
+    /// How often to capture a frame for the video, in simulation time steps.
+    #[serde(default = "default_graph_period")]
+    pub graph_period: u16,
+    /// How large of a magnitude to graph on the y-axis.
+    #[serde(default = "default_range")]
+    pub range: f32,
+    /// Where to store the movie at the end of the simulation.
+    pub path: String,
+    /// What resolution to use for the movie, in pixels.
+    #[serde(default = "default_resolution")]
+    pub resolution: (u16, u16),
+    /// How many snapshots to buffer in memory before starting a child process to render them into
+    /// movie frames.
+    #[serde(default = "default_snapshot_buffer_len")]
+    pub snapshot_buffer_len: u16,
+}
+
+/// An Oscilloscope is a tool for the user to request for simulation data to be captured.
+#[derive(PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "type")]
+pub enum Oscilloscope {
+    /// Record a movie of the simulation.
+    Movie(Movie),
+}
+
+/// Define a signal to place into the simulation space.
+#[derive(PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct Signal {
+    /// Where in the simulation space to place the signal.
+    pub location: usize,
+    /// A path to a BSON file on disk that contains the signal values.
+    pub path: String,
+}
+
+/// Define a configuration for a simulation.
+#[derive(PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "snake_case")]
+pub struct Simulation {
+    /// A list of oscilloscopes to measure data in the simulation.
+    pub oscilloscopes: Vec<Oscilloscope>,
+    /// A list of signals to place into the simulation space.
+    pub signals: Vec<Signal>,
+    /// How many units large the universe is.
+    pub size: u64,
+    /// How long the universe will last until it all comes to an end.
+    pub time: u64,
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -30,7 +30,7 @@ use crate::config;
 /// The known universe.
 pub struct Universe<'a> {
     /// Store a reference to our simulation configuration for easy access.
-    config: &'a config::OneDSimulation,
+    config: &'a config::d1::Simulation,
     /// The electric field for the entire universe.
     pub ex: Vec<f64>,
     /// The magnetic field for the entire universe.
@@ -52,7 +52,7 @@ impl<'a> Universe<'a> {
     ///
     /// A Universe, or an Error if one of the signals cannot be read.
     pub fn in_the_beginning(
-        config: &'a config::OneDSimulation,
+        config: &'a config::d1::Simulation,
     ) -> Result<Universe<'a>, Box<dyn error::Error>> {
         let ex = (0..config.size).map(|_| 0.0).collect::<Vec<f64>>();
         let hy = (0..config.size).map(|_| 0.0).collect::<Vec<f64>>();
@@ -128,7 +128,7 @@ impl<'a> Universe<'a> {
 /// An Oscilloscope records data from the Universe.
 pub struct Oscilloscope<'a> {
     /// The oscilloscope's configuration.
-    config: &'a config::Oscilloscope,
+    config: &'a config::d1::Oscilloscope,
     /// A list of snapshots that the Oscilloscope has recorded.
     snapshots: Vec<Snapshot>,
     temp_dir: tempfile::TempDir,
@@ -144,7 +144,7 @@ impl<'b> Oscilloscope<'b> {
     /// # Returns
     ///
     /// A new Oscilloscope. Congrats. Or an Error. Condolences.
-    pub fn new(config: &config::Oscilloscope) -> Result<Oscilloscope, Box<dyn error::Error>> {
+    pub fn new(config: &config::d1::Oscilloscope) -> Result<Oscilloscope, Box<dyn error::Error>> {
         let temp_dir = tempdir()?;
         Ok(Oscilloscope {
             config,
@@ -156,7 +156,7 @@ impl<'b> Oscilloscope<'b> {
     /// Close the oscilloscope. A Movie scope will generate its movie at this step.
     pub fn close(&self) {
         match self.config {
-            config::Oscilloscope::Movie(movie) => {
+            config::d1::Oscilloscope::Movie(movie) => {
                 let args = format!(
                     "-r {framerate} -f image2 -i {temp_dir}/t%04d.png -vcodec libx264 -crf 25 \
                     -pix_fmt yuv420p {path}",
@@ -188,7 +188,7 @@ impl<'b> Oscilloscope<'b> {
     ///   into it.
     pub fn flush<'a>(&mut self, thread_scope: &rayon::Scope<'a>) {
         match self.config {
-            config::Oscilloscope::Movie(movie) => {
+            config::d1::Oscilloscope::Movie(movie) => {
                 let graph_period = movie.graph_period;
                 let range = movie.range;
                 let resolution = movie.resolution;
@@ -251,7 +251,7 @@ impl<'b> Oscilloscope<'b> {
         hy: &[f64],
     ) {
         match self.config {
-            config::Oscilloscope::Movie(movie) => {
+            config::d1::Oscilloscope::Movie(movie) => {
                 if timestamp % (movie.graph_period as u64) == 0 {
                     let snapshot = Snapshot {
                         timestamp,
@@ -281,7 +281,7 @@ pub struct SignalBSON {
 /// This struct represents a signal in space, and is a wrapper around both the configuration for
 /// the signal and the interpreted BSON data.
 pub struct Signal<'a> {
-    pub config: &'a config::Signal,
+    pub config: &'a config::d1::Signal,
     pub bson: SignalBSON,
 }
 
@@ -295,7 +295,7 @@ impl<'b> Signal<'b> {
     /// # Returns
     ///
     /// A new signal, or an Error if the BSON file was not able to be read or was not valid.
-    pub fn new(config: &config::Signal) -> Result<Signal, Box<dyn error::Error>> {
+    pub fn new(config: &config::d1::Signal) -> Result<Signal, Box<dyn error::Error>> {
         let f = File::open(&config.path)?;
         let mut reader = BufReader::new(f);
         let bson = bson::Document::from_reader(&mut reader)?;


### PR DESCRIPTION
In preparation for adding 2D and 3D capabilities to rems, this
commit adds a d1 namespace to the config module. The name is odd,
but names cannot start with integers in Rust, and conventionally
module names are lowercase, so we write d1 instead of 1D.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>