### PR TITLE
Run CI nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Pull request checks
+name: CI
 
 on:
   push:
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI](https://github.com/bowlofeggs/rems/workflows/CI/badge.svg?branch=master)
+
 ```rems``` (Rust ElectroMagnetic Simulator) is a
 [Finite Difference Time Domain](https://en.wikipedia.org/wiki/Finite-difference_time-domain_method)
 (FDTD) simulator written in Rust.


### PR DESCRIPTION
This also renames the job to CI since it does not only check pull
requests. It also adds a badge.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>