### PR TITLE
RUSTSEC-2021-0003: Update to smallvec 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "strsim"


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2021-0003

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>