### PR TITLE
Correct CHANGELOG URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 0.0.15
 
 * [RUSTSEC-2023-0075](https://rustsec.org/advisories/RUSTSEC-2023-0075.html): Update
-  `unsafe-libyaml` to `0.2.10` ([#353](https://github.com/bowlofeggs/rpick/pull/353)).
+  `unsafe-libyaml` to `0.2.10` ([#178](https://github.com/bowlofeggs/rems/pull/178)).
 * [GHSA-c827-hfw6-qwvm](https://github.com/advisories/GHSA-c827-hfw6-qwvm): Update
-  `rustix` to `0.38.30` ([#359](https://github.com/bowlofeggs/rpick/pull/359)).
+  `rustix` to `0.38.30` ([#180](https://github.com/bowlofeggs/rems/pull/180)).
 * Update dependencies.
 
 # 0.0.14


### PR DESCRIPTION
I had shamefully copied some URLs from rpick's changelog without fixing up the pull requests to be for rems.